### PR TITLE
Add support for ppc64le architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,51 @@
 branches:
   only:
     - master
+    - ppc64le_support
 language: ruby
 services:
   - docker
-script:
-  - make test
+env: 
+  global:
+    - VERSION=1.9.0
+    - IMAGE=murilofv/base-builder
+
+stages:
+  - Test
+  - Arch-Release
+  - Manifest-Release
+
+jobs:
+  include:
+    - stage: Test
+      arch: amd64
+      os: linux
+      script: make test
+    - stage: Test
+      arch: ppc64le
+      os: linux
+      script: make test
+
+    - stage: Arch-Release
+      os: linux
+      arch: amd64
+      script:
+        - ARCH_RELEASE=0
+        - docker pull $IMAGE:$VERSION-$TRAVIS_CPU_ARCH || ARCH_RELEASE=1
+        - "[ ${ARCH_RELEASE} == 1 ] && (make release DOCKER_USER=$DOCKER_USER DOCKER_PASS=$DOCKER_PASS IMAGE=$IMAGE TAG=$VERSION)"
+    - stage: Arch-Release
+      os: linux
+      arch: ppc64le
+      script:
+        - ARCH_RELEASE=0
+        - docker pull $IMAGE:$VERSION-$TRAVIS_CPU_ARCH || ARCH_RELEASE=1
+        - "[ ${ARCH_RELEASE} == 1 ] && (make release DOCKER_USER=$DOCKER_USER DOCKER_PASS=$DOCKER_PASS IMAGE=$IMAGE TAG=$VERSION)"
+
+    - stage: Manifest-Release
+      arch: amd64
+      os: linux
+      script:
+        - export DOCKER_CLI_EXPERIMENTAL=enabled
+        - MANIFEST_RELEASE=0
+        - docker pull $IMAGE:$VERSION || MANIFEST_RELEASE=1
+        - "[ ${MANIFEST_RELEASE} == 1 ] && (make release-manifest DOCKER_USER=$DOCKER_USER DOCKER_PASS=$DOCKER_PASS IMAGE=$IMAGE TAG=$VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,27 @@
-IMAGE=imega/base-builder
+IMAGE=murilofv/base-builder
 TAG=latest
+ARCH=$(shell uname -m)
+
+ifeq ($(ARCH),x86_64)
+	ARCH=amd64
+endif
 
 build:
-	@docker build -t $(IMAGE):$(TAG) .
+	echo $(ARCH)
+	@docker build -t $(IMAGE):$(TAG)-$(ARCH) .
 
 release: build
 	@docker login --username $(DOCKER_USER) --password $(DOCKER_PASS)
-	@docker tag $(IMAGE):$(TAG) $(IMAGE):latest
-	@docker push $(IMAGE):$(TAG)
-	@docker push $(IMAGE):latest
+	@docker tag $(IMAGE):$(TAG)-$(ARCH) $(IMAGE):latest-$(ARCH)
+	@docker push $(IMAGE):$(TAG)-$(ARCH)
+	@docker push $(IMAGE):latest-$(ARCH)
 
+release-manifest:
+	@docker login --username $(DOCKER_USER) --password $(DOCKER_PASS)
+	@docker manifest create $(IMAGE):$(TAG) $(IMAGE):$(TAG)-amd64 $(IMAGE):$(TAG)-ppc64le
+	@docker manifest create $(IMAGE):latest $(IMAGE):latest-amd64 $(IMAGE):latest-ppc64le
+	@docker manifest push $(IMAGE):$(TAG)
+	@docker manifest push $(IMAGE):latest
 
 test: build
-	$(MAKE) test -C tests
+	$(MAKE) test -C tests IMAGE=$(IMAGE) TAG=$(TAG)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,10 +1,18 @@
+IMAGE=murilofv/base-builder
+TAG=latest
+ARCH=$(shell uname -m)
+
+ifeq ($(ARCH),x86_64)
+        ARCH=amd64
+endif
+
 build: build-fs
 	@docker build -t imega/tidy .
 
 build-fs:
 	@docker run --rm=false \
 		-v $(CURDIR)/build:/build \
-		imega/base-builder \
+		$(IMAGE):$(TAG)-$(ARCH) \
 		--packages="tidyhtml"
 
 test: build


### PR DESCRIPTION
This commit add ppc64le support and makes travis build to both amd64 and
ppc64le architectures and generates a fat manifest that could be used as
a pointer in case it doesn't exist already in the repo. This way an
already existent container doesn't get overwritten and a new one can be
built by changing the release version on .travis.yml

Signed-off-by: Murilo Fossa Vicentini <muvic@linux.ibm.com>