### PR TITLE
Add support for ppc64le architecture

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          make test -C tests || exit 1
+          make test || exit 1
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,6 @@ jobs:
       - checkout
       - run: |
           make test -C tests || exit 1
-  release:
-    machine:
-      enabled: true
-    steps:
-      - checkout
-      - run: |
-          make release TAG=$CIRCLE_TAG || exit 1
 
 workflows:
   version: 2
@@ -24,11 +17,3 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - release:
-          requires:
-            - tests
-          filters:
-            tags:
-              only: /[0-9]+(\.[0-9]+)*/
-            branches:
-              ignore: /.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ branches:
 language: ruby
 services:
   - docker
-env: 
+env:
   global:
-    - VERSION=1.9.0
-    - IMAGE=murilofv/base-builder
+    - VERSION=1.9.1
+    - IMAGE=imega/base-builder
 
 stages:
   - Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-branches:
-  only:
-    - master
-    - ppc64le_support
 language: ruby
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,51 @@
 branches:
   only:
     - master
+    - ppc64le_support
 language: ruby
 services:
   - docker
-script:
-  - make test
+env: 
+  global:
+    - VERSION=1.9.0
+    - IMAGE=murilofv/base-builder
+
+stages:
+  - Test
+  - Arch-Release
+  - Manifest-Release
+
+jobs:
+  include:
+    - stage: Test
+      arch: amd64
+      os: linux
+      script: make test
+    - stage: Test
+      arch: ppc64le
+      os: linux
+      script: make test
+
+    - stage: Arch-Release
+      os: linux
+      arch: amd64
+      script:
+        - ARCH_RELEASE=0
+        - docker pull $IMAGE:$VERSION-$TRAVIS_CPU_ARCH || ARCH_RELEASE=1
+        - "[ ${ARCH_RELEASE} == 1 ] && (make release DOCKER_USER=$DOCKER_USER DOCKER_PASS=$DOCKER_PASS IMAGE=$IMAGE TAG=$VERSION)"
+    - stage: Arch-Release
+      os: linux
+      arch: ppc64le
+      script:
+        - ARCH_RELEASE=0
+        - docker pull $IMAGE:$VERSION-$TRAVIS_CPU_ARCH || ARCH_RELEASE=1
+        - "[ ${ARCH_RELEASE} == 1 ] && (make release DOCKER_USER=$DOCKER_USER DOCKER_PASS=$DOCKER_PASS IMAGE=$IMAGE TAG=$VERSION)"
+
+    - stage: Manifest-Release
+      arch: amd64
+      os: linux
+      script:
+        - export DOCKER_CLI_EXPERIMENTAL=enabled
+        - MANIFEST_RELEASE=0
+        - docker pull $IMAGE:$VERSION || MANIFEST_RELEASE=1
+        - "[ ${MANIFEST_RELEASE} == 1 ] && (make release-manifest DOCKER_USER=$DOCKER_USER DOCKER_PASS=$DOCKER_PASS IMAGE=$IMAGE TAG=$VERSION)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
       script: make test
 
     - stage: Arch-Release
+      if: branch = master
       os: linux
       arch: amd64
       script:
@@ -34,6 +35,7 @@ jobs:
         - docker pull $IMAGE:$VERSION-$TRAVIS_CPU_ARCH || ARCH_RELEASE=1
         - "[ ${ARCH_RELEASE} == 1 ] && (make release DOCKER_USER=$DOCKER_USER DOCKER_PASS=$DOCKER_PASS IMAGE=$IMAGE TAG=$VERSION)"
     - stage: Arch-Release
+      if: branch = master
       os: linux
       arch: ppc64le
       script:
@@ -42,6 +44,7 @@ jobs:
         - "[ ${ARCH_RELEASE} == 1 ] && (make release DOCKER_USER=$DOCKER_USER DOCKER_PASS=$DOCKER_PASS IMAGE=$IMAGE TAG=$VERSION)"
 
     - stage: Manifest-Release
+      if: branch = master
       arch: amd64
       os: linux
       script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### [1.9.1]
+
+-   Add support for ppc64le architecture #7 (Murilo Fossa Vicentini muvic@linux.ibm.com)
+
 ### [1.9.0]
 
 -   Update alpine version 3.10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 
 LABEL maintainer="Dmitry Stoletoff info@imega<dot>ru" \
-    version="1.9.0" \
+    version="1.9.1" \
     description="Create rootfs for docker."
 
 VOLUME ["/build", "/src", "/runner"]

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,27 @@
-IMAGE=imega/base-builder
+IMAGE=murilofv/base-builder
 TAG=latest
+ARCH=$(shell uname -m)
+
+ifeq ($(ARCH),x86_64)
+	ARCH=amd64
+endif
 
 build:
-	@docker build -t $(IMAGE):$(TAG) .
+	echo $(ARCH)
+	@docker build -t $(IMAGE):$(TAG)-$(ARCH) .
 
 release: build
 	@docker login --username $(DOCKER_USER) --password $(DOCKER_PASS)
-	@docker tag $(IMAGE):$(TAG) $(IMAGE):latest
-	@docker push $(IMAGE):$(TAG)
-	@docker push $(IMAGE):latest
+	@docker tag $(IMAGE):$(TAG)-$(ARCH) $(IMAGE):latest-$(ARCH)
+	@docker push $(IMAGE):$(TAG)-$(ARCH)
+	@docker push $(IMAGE):latest-$(ARCH)
 
+release-manifest:
+	@docker login --username $(DOCKER_USER) --password $(DOCKER_PASS)
+	@docker manifest create $(IMAGE):$(TAG) $(IMAGE):$(TAG)-amd64 $(IMAGE):$(TAG)-ppc64le
+	@docker manifest create $(IMAGE):latest $(IMAGE):latest-amd64 $(IMAGE):latest-ppc64le
+	@docker manifest push $(IMAGE):$(TAG)
+	@docker manifest push $(IMAGE):latest
 
 test: build
-	$(MAKE) test -C tests
+	$(MAKE) test -C tests IMAGE=$(IMAGE) TAG=$(TAG)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE=murilofv/base-builder
+IMAGE=imega/base-builder
 TAG=latest
 ARCH=$(shell uname -m)
 
@@ -7,17 +7,17 @@ ifeq ($(ARCH),x86_64)
 endif
 
 build:
-	echo $(ARCH)
 	@docker build -t $(IMAGE):$(TAG)-$(ARCH) .
 
-release: build
+login:
 	@docker login --username $(DOCKER_USER) --password $(DOCKER_PASS)
+
+release: login build
 	@docker tag $(IMAGE):$(TAG)-$(ARCH) $(IMAGE):latest-$(ARCH)
 	@docker push $(IMAGE):$(TAG)-$(ARCH)
 	@docker push $(IMAGE):latest-$(ARCH)
 
-release-manifest:
-	@docker login --username $(DOCKER_USER) --password $(DOCKER_PASS)
+release-manifest: login
 	@docker manifest create $(IMAGE):$(TAG) $(IMAGE):$(TAG)-amd64 $(IMAGE):$(TAG)-ppc64le
 	@docker manifest create $(IMAGE):latest $(IMAGE):latest-amd64 $(IMAGE):latest-ppc64le
 	@docker manifest push $(IMAGE):$(TAG)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,10 +1,18 @@
+IMAGE=murilofv/base-builder
+TAG=latest
+ARCH=$(shell uname -m)
+
+ifeq ($(ARCH),x86_64)
+        ARCH=amd64
+endif
+
 build: build-fs
 	@docker build -t imega/tidy .
 
 build-fs:
 	@docker run --rm=false \
 		-v $(CURDIR)/build:/build \
-		imega/base-builder \
+		$(IMAGE):$(TAG)-$(ARCH) \
 		--packages="tidyhtml"
 
 test: build

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-IMAGE=murilofv/base-builder
+IMAGE=imega/base-builder
 TAG=latest
 ARCH=$(shell uname -m)
 


### PR DESCRIPTION
This commit add ppc64le support and makes travis build to both amd64 and
ppc64le architectures and generates a fat manifest that could be used as
a pointer in case it doesn't exist already in the repo. This way an
already existent container doesn't get overwritten and a new one can be
built by changing the release version on .travis.yml

Signed-off-by: Murilo Fossa Vicentini <muvic@linux.ibm.com>